### PR TITLE
compatible with IE

### DIFF
--- a/src/components/helpers/get-ua-data.js
+++ b/src/components/helpers/get-ua-data.js
@@ -30,6 +30,6 @@ export const getNavigatorInstance = () => {
 export const isIOS13Check = type => {
   const nav = getNavigatorInstance();
   return (
-    nav && (nav.platform.includes(type) || (nav.platform === 'MacIntel' && nav.maxTouchPoints > 1 && !window.MSStream))
+    nav && (nav.platform.indexOf(type) !== -1 || (nav.platform === 'MacIntel' && nav.maxTouchPoints > 1 && !window.MSStream))
   );
 };

--- a/src/components/helpers/selectors.js
+++ b/src/components/helpers/selectors.js
@@ -34,7 +34,7 @@ const isElectronType = () => {
   const nav = getNavigatorInstance();
   const ua = nav && nav.userAgent.toLowerCase();
 
-  return typeof ua === 'string' ? ua.includes('electron') : false;
+  return typeof ua === 'string' ? /electron/.test(ua) : false;
 };
 
 const getIOS13 = () => {


### PR DESCRIPTION
replace `includes` method to `test` or `indexOf`.

[Issue on IE ](https://github.com/duskload/react-device-detect/issues/71)