### PR TITLE
Prevent crashes incase `nav.platform` is undefined

### DIFF
--- a/src/components/helpers/get-ua-data.js
+++ b/src/components/helpers/get-ua-data.js
@@ -30,6 +30,6 @@ export const getNavigatorInstance = () => {
 export const isIOS13Check = type => {
   const nav = getNavigatorInstance();
   return (
-    nav && (nav.platform.indexOf(type) !== -1 || (nav.platform === 'MacIntel' && nav.maxTouchPoints > 1 && !window.MSStream))
+    nav && nav.platform && (nav.platform.indexOf(type) !== -1 || (nav.platform === 'MacIntel' && nav.maxTouchPoints > 1 && !window.MSStream))
   );
 };


### PR DESCRIPTION
This should fix this error I'm seeing:

![image](https://user-images.githubusercontent.com/32533397/81247437-db176580-8fce-11ea-8344-b1656e2359fd.png)
