### PR TITLE
Add isMIUI helper

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,6 +61,7 @@ declare module "react-device-detect" {
   export import isWindows = ReactDeviceDetect.isWindows;
   export import isMacOs = ReactDeviceDetect.isMacOs;
   export import withOrientationChange = ReactDeviceDetect.withOrientationChange;
+  export import isMIUI = ReactDeviceDetect.isMIUI;
 }
 
 declare namespace ReactDeviceDetect {
@@ -196,4 +197,6 @@ declare namespace ReactDeviceDetect {
   export const isWindows: boolean;
 
   export const isMacOs: boolean;
+
+  export const isMIUI: boolean;
 }

--- a/main.js
+++ b/main.js
@@ -204,7 +204,8 @@ var BROWSER_TYPES = {
   CHROMIUM: "Chromium",
   IE: 'IE',
   MOBILE_SAFARI: "Mobile Safari",
-  EDGE_CHROMIUM: "Edge Chromium"
+  EDGE_CHROMIUM: "Edge Chromium",
+  MIUI: "MIUI Browser"
 };
 var OS_TYPES = {
   IOS: 'iOS',
@@ -444,6 +445,10 @@ var isIEType = function isIEType() {
   return browser.name === BROWSER_TYPES.INTERNET_EXPLORER || browser.name === BROWSER_TYPES.IE;
 };
 
+var isMIUIType = function isMIUIType() {
+  return browser.name === BROWSER_TYPES.MIUI;
+};
+
 var isElectronType = function isElectronType() {
   var nav = getNavigatorInstance();
   var ua = nav && nav.userAgent.toLowerCase();
@@ -550,6 +555,7 @@ var isEdgeChromium = isEdgeChromiumType();
 var isLegacyEdge = isEdgeType();
 var isWindows = isWindowsType();
 var isMacOs = isMacOsType();
+var isMIUI = isMIUIType();
 
 var AndroidView = function AndroidView(_ref) {
   var renderWithFragment = _ref.renderWithFragment,
@@ -789,6 +795,7 @@ exports.isIPad13 = isIPad13;
 exports.isIPhone13 = isIPhone13;
 exports.isIPod13 = isIPod13;
 exports.isLegacyEdge = isLegacyEdge;
+exports.isMIUI = isMIUI;
 exports.isMacOs = isMacOs;
 exports.isMobile = isMobile;
 exports.isMobileOnly = isMobileOnly;

--- a/src/components/helpers/selectors.js
+++ b/src/components/helpers/selectors.js
@@ -40,6 +40,7 @@ const isSafariType = () => browser.name === BROWSER_TYPES.SAFARI || browser.name
 const isMobileSafariType = () => browser.name === BROWSER_TYPES.MOBILE_SAFARI;
 const isOperaType = () => browser.name === BROWSER_TYPES.OPERA;
 const isIEType = () => browser.name === BROWSER_TYPES.INTERNET_EXPLORER || browser.name === BROWSER_TYPES.IE;
+const isMIUIType = () => browser.name === BROWSER_TYPES.MIUI;
 const isElectronType = () => {
   const nav = getNavigatorInstance();
   const ua = nav && nav.userAgent.toLowerCase();
@@ -111,3 +112,4 @@ export const isEdgeChromium = isEdgeChromiumType();
 export const isLegacyEdge = isEdgeType();
 export const isWindows = isWindowsType();
 export const isMacOs = isMacOsType();
+export const isMIUI = isMIUIType();

--- a/src/components/helpers/types.js
+++ b/src/components/helpers/types.js
@@ -20,7 +20,8 @@ export const BROWSER_TYPES = {
   CHROMIUM: "Chromium",
   IE: 'IE',
   MOBILE_SAFARI: "Mobile Safari",
-  EDGE_CHROMIUM: "Edge Chromium"
+  EDGE_CHROMIUM: "Edge Chromium",
+  MIUI: "MIUI Browser"
 };
 
 export const OS_TYPES = {


### PR DESCRIPTION
The ua-parser-js library already provides a way to find out if the browser is an MIUI, I just added the check

[ua-parser-js](https://github.com/faisalman/ua-parser-js#methods)

# Possible 'browser.name':
2345Explorer, 360 Browser, Amaya, Android Browser, Arora, Avant, Avast, AVG, 
BIDUBrowser, Baidu, Basilisk, Blazer, Bolt, Brave, Bowser, Camino, Chimera, 
Chrome Headless, Chrome WebView, Chrome, Chromium, Comodo Dragon, Dillo, 
Dolphin, Doris, Edge, Epiphany, Facebook, Falkon, Fennec, Firebird, Firefox, 
Flock, GSA, GoBrowser, ICE Browser, IE, IEMobile, IceApe, IceCat, IceDragon, 
Iceape, Iceweasel, Iridium, Iron, Jasmine, K-Meleon, Kindle, Konqueror, 
LBBROWSER Line, Links, Lunascape, Lynx, **MIUI Browser**, Maemo Browser, Maemo, 
Maxthon, MetaSr Midori, Minimo, Mobile Safari, Mosaic, Mozilla, NetFront, 
NetSurf, Netfront, Netscape, NokiaBrowser, Oculus Browser, OmniWeb, 
Opera Coast, Opera Mini, Opera Mobi, Opera Tablet, Opera, PaleMoon, PhantomJS, 
Phoenix, Polaris, Puffin, QQ, QQBrowser, QQBrowserLite, Quark, QupZilla, 
RockMelt, Safari, Sailfish Browser, Samsung Browser, SeaMonkey, Silk, Skyfire, 
Sleipnir, Slim, SlimBrowser, Swiftfox, Tizen Browser, UCBrowser, Vivaldi, 
Waterfox, WeChat, Yandex, baidu, iCab, w3m, ..