### PR TITLE
Change isLegacyEdge to be false if isEdgeChromium

### DIFF
--- a/src/components/helpers/selectors.js
+++ b/src/components/helpers/selectors.js
@@ -108,6 +108,6 @@ export const isIPhone13 = getIphone13();
 export const isIPod13 = getIPod13();
 export const isElectron = isElectronType();
 export const isEdgeChromium = isEdgeChromiumType();
-export const isLegacyEdge = isEdgeType();
+export const isLegacyEdge = isEdgeType() && !isEdgeChromiumType();
 export const isWindows = isWindowsType();
 export const isMacOs = isMacOsType();


### PR DESCRIPTION
Fixes #94. 

I also ran into this bug for my use case. On some versions of Chromium Edge `isLegacyEdge` would return `true`.