### PR TITLE
Allow React 17 as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "console"
   ],
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
+    "react": ">= 0.14.0 < 18.0.0",
+    "react-dom": ">= 0.14.0 < 18.0.0"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
This fixes an "incorrect peer dependency" warning when using react-device-detect in a React 17 project.