### PR TITLE
identify iPad pro iOS 13+ that use new desktop engine on safari browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -32,7 +32,7 @@ var getNavigatorInstance = function getNavigatorInstance() {
 };
 var isIOS13Check = function isIOS13Check(type) {
   var nav = getNavigatorInstance();
-  return nav && nav.platform && (nav.platform.indexOf(type) !== -1 || nav.platform === 'MacIntel' && nav.maxTouchPoints > 1 && !window.MSStream);
+  return nav && nav.platform && (nav.platform.indexOf(type) !== -1 || nav.platform === 'MacIntel' && nav.maxTouchPoints > 0);
 };
 
 function _typeof(obj) {

--- a/src/components/helpers/get-ua-data.js
+++ b/src/components/helpers/get-ua-data.js
@@ -30,6 +30,6 @@ export const getNavigatorInstance = () => {
 export const isIOS13Check = type => {
   const nav = getNavigatorInstance();
   return (
-    nav && nav.platform && (nav.platform.indexOf(type) !== -1 || (nav.platform === 'MacIntel' && nav.maxTouchPoints > 1 && !window.MSStream))
+    nav && nav.platform && (nav.platform.indexOf(type) !== -1 || (nav.platform === 'MacIntel' && nav.maxTouchPoints > 0))
   );
 };


### PR DESCRIPTION
Apple Ipad pro on IOS 13 + uses a new desktop engine on safari. 