### PR TITLE
Update isElectronType helper

### DIFF
--- a/src/components/helpers/selectors.js
+++ b/src/components/helpers/selectors.js
@@ -39,7 +39,7 @@ const isIEType = () => browser.name === BROWSER_TYPES.INTERNET_EXPLORER || brows
 const isMIUIType = () => browser.name === BROWSER_TYPES.MIUI;
 const isElectronType = () => {
   const nav = getNavigatorInstance();
-  const ua = nav && nav.userAgent.toLowerCase();
+  const ua = nav && nav.userAgent && nav.userAgent.toLowerCase();
 
   return typeof ua === 'string' ? /electron/.test(ua) : false;
 };


### PR DESCRIPTION
This is a small fix to make the library not crash with `react-native`.
Importing the module causes a runtime error because `navigator.userAgent` is `undefined`:

![IMG_0698](https://user-images.githubusercontent.com/1186409/107950395-f02a1780-6f96-11eb-8d25-2f27b4f09ed4.PNG)

I'm not entirely sure why this is happening, perhaps we should investigate it as part of https://github.com/duskload/react-device-detect/issues/107 🤔 

---

I created a small project to reproduce the error:

- open https://snack.expo.io/YhSMzq2vm
- click on the iOS tab and tap on the play button

